### PR TITLE
Add impressum footer and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,23 @@
-import { Container, AppBar, Box, Toolbar } from "@mui/material";
-import { Route, Routes, Navigate } from "react-router-dom";
+import {
+  Container,
+  AppBar,
+  Box,
+  Toolbar,
+  Typography,
+  Button,
+} from "@mui/material";
+import { Route, Routes, Navigate, useNavigate } from "react-router-dom";
 import GroceryLists from "./components/GroceryLists";
 import GroceryList from "./components/GroceryList";
 import Login from "./components/Login";
 import { useQuery } from "@apollo/client";
 import { GET_AUTHENTICATED_USER } from "./graphql";
+import Impressum from "./components/Impressum";
 
 function App() {
   const { data } = useQuery(GET_AUTHENTICATED_USER);
+
+  const navigate = useNavigate();
 
   const user = data?.authenticatedUser?.user
     ? data.authenticatedUser.user
@@ -32,9 +42,27 @@ function App() {
             path="/list/:listId"
             element={<GroceryList userId={user?.id} isAuthed={data} />}
           />
+          <Route path="/impressum" element={<Impressum />} />
           <Route path="*" element={<Navigate to="/" />} />
         </Routes>
       </Container>
+      <Container>
+        <Box sx={{ justifyContent: "flex-end" }}>
+          <Typography align={"center"} fontWeight={"bold"}>
+            © Crowdlist
+          </Typography>
+          <Typography align={"center"}>
+            created by Robert Schlick and Benjamin Gutzmann
+          </Typography>
+          <Button
+            style={{ margin: "0 auto", display: "flex" }}
+            onClick={() => navigate("/impressum")}
+          >
+            Impressum
+          </Button>
+        </Box>
+      </Container>
+      <Container></Container>
     </Container>
   );
 }

--- a/src/components/Impressum.tsx
+++ b/src/components/Impressum.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Container, Typography } from "@mui/material";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+const Impressum = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <Container>
+        <Button onClick={() => navigate("/")}>Zurück zum Start</Button>
+        <Box>
+          <Typography fontWeight={"bold"} fontSize={30}>
+            Impressum
+          </Typography>
+          <Box component="p">Anbieter:</Box>
+          <Box component="p" marginLeft={2}>
+            <Box component="p">Robert Schlick</Box>
+            <Box component="p">Erichstraße 9</Box>
+            <Box component="p">20359 Hamburg</Box>
+          </Box>
+          <Box component="p">Kontakt:</Box>
+          <Box component="p" marginLeft={2}>
+            <Button
+              variant="text"
+              size={"small"}
+              href={"mailto:robert@schlick.it"}
+            >
+              robert@schlick.it
+            </Button>
+          </Box>
+        </Box>
+      </Container>
+    </>
+  );
+};
+export default Impressum;


### PR DESCRIPTION
Dear @Roschl ,

please check out this PR that adds an impressum to the app. It consists of a page footer for all pages and a separate site with the typical information as expected of an impressum page.

The only thing that bothers me is that for pages that dont fill the entire screen the impressum is moved up a bit and is fitted just below the last content of that page.

Cheers,
Benjamin